### PR TITLE
#27: Make the scrollup animation time parametric (closes #27)

### DIFF
--- a/src/components/ResultsPanel/ResultsPanel.js
+++ b/src/components/ResultsPanel/ResultsPanel.js
@@ -49,7 +49,7 @@ export default class ResultsPanel extends React.Component {
               }
           }
           </ScrollView>
-          <button className="back-to-top" style={{position:'absolute'}} onClick={()=> this.scrollTo(0, 0, 1500)}><i className="fa fa-arrow-up"></i></button>
+          <button className="back-to-top" style={{position:'absolute'}} onClick={()=> this.scrollTo(0, 0, results.length < 15 ? results.length * 100: 1500)}><i className="fa fa-arrow-up"></i></button>
         </Panel>
     );
   }

--- a/src/components/ResultsPanel/ResultsPanel.js
+++ b/src/components/ResultsPanel/ResultsPanel.js
@@ -49,7 +49,7 @@ export default class ResultsPanel extends React.Component {
               }
           }
           </ScrollView>
-          <button className="back-to-top" style={{position:'absolute'}} onClick={()=> this.scrollTo(0, 0, results.length < 15 ? results.length * 100: 1500)}><i className="fa fa-arrow-up"></i></button>
+          <button className="back-to-top" style={{position:'absolute'}} onClick={()=> this.scrollTo(0, 0, Math.min(1500, results.length * 100))}><i className="fa fa-arrow-up"></i></button>
         </Panel>
     );
   }


### PR DESCRIPTION
Issue #27
## Test Plan

**Alert** : to actually test this code you have to add object to `fakeResult` on the top of `App.js`
- Search for `reactjs` and you will get fake results
- Scroll down and click the `back-to-top` button, you will be scrolled up with ease animation. Add and remove the number of the results and you will check if seems fluid enough.

PS: (Can be improved a little bit more IMHO, but is just fine for now)
